### PR TITLE
Matrix extensions & Complex numbers

### DIFF
--- a/src/nl/rubensten/utensils/math/Complex.kt
+++ b/src/nl/rubensten/utensils/math/Complex.kt
@@ -1,0 +1,275 @@
+import nl.rubensten.utensils.math.matrix.isZero
+import java.io.Serializable
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * A complex number `a+b<i>i</i>`.
+ *
+ * @author Ruben Schellekens
+ */
+class Complex(val a: Double, val b: Double) : Serializable {
+
+    companion object {
+
+        private val serialVersionUID = 96062259058757105L
+
+        /** 1+0i  */
+        @JvmField val ONE = Complex(1.0, 0.0)
+        /** 1+1i  */
+        @JvmField val ONE_EIGTH = Complex(1.0, 1.0)
+        /** 0+1i  */
+        @JvmField val I = Complex(0.0, 1.0)
+        /** -1+1i  */
+        @JvmField val THREE_EIGHTS = Complex(-1.0, 1.0)
+        /** -1+0i  */
+        @JvmField val HALF = Complex(-1.0, 0.0)
+        /** -1-1i  */
+        @JvmField val MINUS_THREE_EIGHTS = Complex(-1.0, -1.0)
+        /** 0-i1  */
+        @JvmField val THREE_QUARTS = Complex(0.0, -1.0)
+        /** 1-1i  */
+        @JvmField val SEVEN_EIGHTS = Complex(1.0, -1.0)
+
+        /**
+         * Parses from the format "a+bi" or "a-bi".
+         */
+        @JvmStatic
+        fun parse(complexString: String): Complex {
+            var toSetA: Double
+            var toSetB: Double
+
+            try {
+                val elements = complexString.replace(" ".toRegex(), "")
+                        .split("\\+".toRegex())
+                        .dropLastWhile({ it.isEmpty() })
+                        .toTypedArray()
+                toSetA = java.lang.Double.parseDouble(elements[0])
+                toSetB = java.lang.Double.parseDouble(elements[1].replace("i", ""))
+            }
+            catch (e: NumberFormatException) {
+                val startsWithMinus = complexString.trim({ it <= ' ' }).startsWith("-")
+                val elements = complexString.replace(" ".toRegex(), "")
+                        .split("-".toRegex())
+                        .dropLastWhile({ it.isEmpty() })
+                        .toTypedArray()
+
+                val real: String
+                val imag: String
+                if (startsWithMinus) {
+                    real = "-" + elements[1]
+                    imag = "-" + elements[2].replace("i", "")
+                }
+                else {
+                    real = elements[0]
+                    imag = "-" + elements[1].replace("i", "")
+                }
+
+                toSetA = java.lang.Double.parseDouble(real)
+                toSetB = java.lang.Double.parseDouble(imag)
+            }
+
+            return Complex(toSetA, toSetB)
+        }
+    }
+
+    /**
+     * Rotates the complex number over a certain angle in radians.
+     *
+     * @param angle
+     *            The angle in radians.
+     * @return A new complex number where `z=this*e^θi`.
+     */
+    infix fun rotate(angle: Double): Complex {
+        val a = cos(angle)
+        val b = sin(angle)
+        val w = Complex(a, b)
+        return multiply(w)
+    }
+
+    /**
+     * Divides this complex number by the given complex number.
+     *
+     * @return A new complex number `z=this/c`.
+     */
+    infix fun divide(other: Complex): Complex {
+        val re = other.real()
+        val im = other.imag()
+        val bottom = re * re + im * im
+        val newA = (real() * re + imag() * im) / bottom
+        val newB = (imag() * re - real() * im) / bottom
+        return Complex(newA, newB)
+    }
+
+    /**
+     * Divides this complex number by a scalar.
+     *
+     * @return A new complex number `z=this*(1/scalar)`.
+     */
+    infix fun divide(scalar: Double) = multiply(1.0 / scalar)
+
+    /**
+     * Mutiplies a complex number to this complex number.
+     *
+     * @return A new complex number `z=this*c`.
+     */
+    infix fun multiply(other: Complex): Complex {
+        val newA = a * other.real() - b * other.imag()
+        val newB = a * other.imag() + b * other.real()
+        return Complex(newA, newB)
+    }
+
+    /**
+     * Multiplies the complex number with a scalar.
+     *
+     * @return A new complex number `z=this*c`
+     */
+    infix fun multiply(scalar: Double): Complex {
+        return Complex(scalar * a, scalar * b)
+    }
+
+    /**
+     * Substracts a complex number from this complex number.
+     *
+     * @return A new complex number `z=this-c`.
+     */
+    infix fun subtract(other: Complex): Complex {
+        val newA = real() - other.real()
+        val newB = imag() - other.imag()
+        return Complex(newA, newB)
+    }
+
+    /**
+     * Subtracts a number to the complex number.
+     *
+     * @return A new complex number `z=this-number`.
+     */
+    infix fun subtract(number: Double): Complex {
+        return Complex(a - number, b)
+    }
+
+    /**
+     * Adds a complex number to this complex number.
+     *
+     * @return A new complex number `z=this+c`.
+     */
+    infix fun add(other: Complex): Complex {
+        val newA = real() + other.real()
+        val newB = imag() + other.imag()
+        return Complex(newA, newB)
+    }
+
+    /**
+     * Adds a number to the complex number.
+     *
+     * @return A new complex number `z=this+number`.
+     */
+    infix fun add(number: Double): Complex {
+        return Complex(a + number, b)
+    }
+
+    /**
+     * Get the conjucated Complex number (a-bi).
+     */
+    fun conj() = Complex(a, -b)
+
+    /**
+     * Returns the real part of the Complex number (a).
+     */
+    fun real() = a
+
+    /**
+     * Returns the imaginary part of the Complex number (b).
+     */
+    fun imag() = b
+
+    /**
+     * Returns the argument (`arg(z)`) of the Complex number.
+     */
+    fun arg() = atan2(b, a)
+
+    /**
+     * Returns the modulus (`|z|`) of the Complex number.
+     */
+    fun modulus() = sqrt(a * a + b * b)
+
+    /** See [add] **/
+    operator fun plus(other: Complex) = add(other)
+
+    /** See [add] **/
+    operator fun plus(number: Number) = add(number.toDouble())
+
+    /** See [subtract] **/
+    operator fun minus(other: Complex) = subtract(other)
+
+    /** See [subtract] **/
+    operator fun minus(number: Number) = subtract(number.toDouble())
+
+    /** See [multiply] **/
+    operator fun times(other: Complex) = multiply(other)
+
+    /** See [multiply] **/
+    operator fun times(number: Number) = multiply(number.toDouble())
+
+    /** See [divide] **/
+    operator fun div(other: Complex) = divide(other)
+
+    /** See [divide] **/
+    operator fun div(number: Number) = divide(number.toDouble())
+
+    /** Multiplies by `-1` **/
+    operator fun unaryMinus() = multiply(-1.0)
+
+    /** Does nothing **/
+    operator fun unaryPlus() = this
+
+    /**
+     * Index 0: a (real part), Index 1: b (imaginary part).
+     *
+     * @throws IndexOutOfBoundsException When index != 1 or 0
+     */
+    operator fun get(index: Int) = when (index) {
+        0 -> a
+        1 -> b
+        else -> throw IndexOutOfBoundsException("Only 0 and 1 allowed, got $index")
+    }
+
+    /**
+     * `a+b*i*`
+     */
+    override fun toString(): String {
+        if (a.isZero() && b.isZero()) {
+            return "0"
+        }
+        else if (a.isZero()) {
+            return b.toString() + "i"
+        }
+        else if (b.isZero()) {
+            return a.toString() + ""
+        }
+
+        val sign = if (b < 0) "" else "+"
+        return a.toString() + sign + b + "i"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Complex) return false
+
+        if (a != other.a) return false
+        if (b != other.b) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = a.hashCode()
+        result = 31 * result + b.hashCode()
+        return result
+    }
+}
+
+/** See [Complex.parse]. **/
+fun String.toComplex() = Complex.parse(this)

--- a/src/nl/rubensten/utensils/math/Complex.kt
+++ b/src/nl/rubensten/utensils/math/Complex.kt
@@ -1,3 +1,5 @@
+package nl.rubensten.utensils.math
+
 import nl.rubensten.utensils.math.matrix.isZero
 import java.io.Serializable
 import kotlin.math.atan2
@@ -16,6 +18,8 @@ class Complex(val a: Double, val b: Double) : Serializable {
 
         private val serialVersionUID = 96062259058757105L
 
+        /** 0 **/
+        @JvmField val ZERO = Complex(0.0, 0.0)
         /** 1+0i  */
         @JvmField val ONE = Complex(1.0, 0.0)
         /** 1+1i  */
@@ -171,6 +175,14 @@ class Complex(val a: Double, val b: Double) : Serializable {
     }
 
     /**
+     * Calculates the inverse of the complex number (`1/z`).
+     */
+    fun inverse(): Complex {
+        val squared = a * a + b * b
+        return Complex(a / squared, -b / squared)
+    }
+
+    /**
      * Get the conjucated Complex number (a-bi).
      */
     fun conj() = Complex(a, -b)
@@ -273,3 +285,6 @@ class Complex(val a: Double, val b: Double) : Serializable {
 
 /** See [Complex.parse]. **/
 fun String.toComplex() = Complex.parse(this)
+
+/** Creates imaginary number `this+other*i` **/
+infix fun Number.i(imaginary: Number) = Complex(this.toDouble(), imaginary.toDouble())

--- a/src/nl/rubensten/utensils/math/Complex.kt
+++ b/src/nl/rubensten/utensils/math/Complex.kt
@@ -286,5 +286,21 @@ class Complex(val a: Double, val b: Double) : Serializable {
 /** See [Complex.parse]. **/
 fun String.toComplex() = Complex.parse(this)
 
+/** Complex number `this*i`. **/
+val Number.i
+    get() = Complex(0.0, this.toDouble())
+
 /** Creates imaginary number `this+other*i` **/
 infix fun Number.i(imaginary: Number) = Complex(this.toDouble(), imaginary.toDouble())
+
+/** See [Complex.add] **/
+operator fun Number.plus(complex: Complex) = complex.add(toDouble())
+
+/** See [Complex.subtract] **/
+operator fun Number.minus(complex: Complex) = complex.subtract(toDouble())
+
+/** See [Complex.multiply] **/
+operator fun Number.times(complex: Complex) = complex.multiply(toDouble())
+
+/** See [Complex.divide] **/
+operator fun Number.div(complex: Complex) = Complex(toDouble(), 0.0) / complex

--- a/src/nl/rubensten/utensils/math/ComplexMatrix.kt
+++ b/src/nl/rubensten/utensils/math/ComplexMatrix.kt
@@ -27,13 +27,11 @@ open class ComplexMatrix : GenericMatrix<Complex> {
             : super(ComplexOperations, builder)
 }
 
-/**
- * @author Ruben Schellekens
- */
-open class ComplexVector : GenericVector<Complex> {
+/** @author Ruben Schellekens **/
+open class ComplexVector(vararg complex: Complex) : GenericVector<Complex>(ComplexOperations, complex.toMutableList()) {
 
-    constructor(complexNumbers: Collection<Complex>) : super(ComplexOperations, complexNumbers.toMutableList())
-    constructor(size: Int, populator: (Int) -> Complex) : super(ComplexOperations, (0 until size).map(populator).toMutableList())
+    constructor(ints: Collection<Complex>) : this(*ints.toTypedArray())
+    constructor(size: Int, populator: (Int) -> Complex) : this(*(0 until size).map(populator).toTypedArray())
 }
 
 /** @author Ruben Schellekens **/
@@ -48,3 +46,18 @@ object ComplexOperations : OperationSet<Complex>(Complex.ZERO, Complex.ONE,
         { Complex(it, 0.0) },
         { _, _ -> throw OperationNotSupportedException() }
 )
+
+//
+//  Extension functions
+//
+
+// Vectors
+fun Array<Complex>.toVector() = ComplexVector(*this)
+fun Collection<Complex>.toVector() = ComplexVector(*toTypedArray())
+infix fun Complex.`&`(other: Complex) = ComplexVector(this, other)
+fun complexVectorOf(vararg complex: Complex) = ComplexVector(*complex)
+
+// Matrices
+fun Array<Vector<Complex>>.toMatrix(major: Major = Major.ROW) = ComplexMatrix(*this, major = major)
+fun List<Vector<Complex>>.toMatrix(major: Major = Major.ROW) = ComplexMatrix(this, major = major)
+fun complexMatrixOf(width: Int, vararg complex: Complex) = ComplexMatrix(*complex, width = width)

--- a/src/nl/rubensten/utensils/math/ComplexMatrix.kt
+++ b/src/nl/rubensten/utensils/math/ComplexMatrix.kt
@@ -44,7 +44,7 @@ object ComplexOperations : OperationSet<Complex>(Complex.ZERO, Complex.ONE,
         { i, j -> i / j },
         { it.inverse() },
         { -it },
-        { if (it.a.isZero() && it.b.isZero()) 0.0 else Double.NaN },
+        { if (it.b.isZero()) it.a else Double.NaN },
         { Complex(it, 0.0) },
         { _, _ -> throw OperationNotSupportedException() }
 )

--- a/src/nl/rubensten/utensils/math/ComplexMatrix.kt
+++ b/src/nl/rubensten/utensils/math/ComplexMatrix.kt
@@ -1,0 +1,50 @@
+package nl.rubensten.utensils.math
+
+import nl.rubensten.utensils.math.matrix.*
+import javax.naming.OperationNotSupportedException
+
+/**
+ * @author Ruben Schellekens
+ */
+open class ComplexMatrix : GenericMatrix<Complex> {
+
+    constructor( major: Major = Major.ROW, vararg vectors: MutableVector<Complex>)
+            : super(ComplexOperations, major, vectors.toMutableList())
+
+    constructor(vectors: List<Vector<Complex>>, major: Major = Major.ROW)
+            : super(ComplexOperations, vectors, major)
+
+    constructor(vararg vectors: Vector<Complex>, major: Major = Major.ROW)
+            : super(ComplexOperations, *vectors, major = major)
+
+    constructor(vararg elements: Complex, width: Int)
+            : super(ComplexOperations, *elements, width = width)
+
+    constructor(height: Int, width: Int, populator: (row: Int, col: Int) -> Complex)
+            : super(ComplexOperations, height, width, populator)
+
+    constructor(builder: MatrixConstruction<Complex>.() -> MatrixConstruction<Complex>)
+            : super(ComplexOperations, builder)
+}
+
+/**
+ * @author Ruben Schellekens
+ */
+open class ComplexVector : GenericVector<Complex> {
+
+    constructor(complexNumbers: Collection<Complex>) : super(ComplexOperations, complexNumbers.toMutableList())
+    constructor(size: Int, populator: (Int) -> Complex) : super(ComplexOperations, (0 until size).map(populator).toMutableList())
+}
+
+/** @author Ruben Schellekens **/
+object ComplexOperations : OperationSet<Complex>(Complex.ZERO, Complex.ONE,
+        { i, j -> i + j },
+        { i, j -> i - j },
+        { i, j -> i * j },
+        { i, j -> i / j },
+        { it.inverse() },
+        { -it },
+        { if (it.a.isZero() && it.b.isZero()) 0.0 else Double.NaN },
+        { Complex(it, 0.0) },
+        { _, _ -> throw OperationNotSupportedException() }
+)

--- a/src/nl/rubensten/utensils/math/arithmetic/ModularIntegerMatrix.kt
+++ b/src/nl/rubensten/utensils/math/arithmetic/ModularIntegerMatrix.kt
@@ -30,16 +30,14 @@ open class ModularIntegerMatrix : GenericMatrix<ModularInteger> {
     )
 }
 
-/**
- * @author Ruben Schellekens
- */
-open class ModularIntegerVector : NumberVector<ModularInteger> {
+/** @author Ruben Schellekens **/
+open class ModularIntegerVector(modulus: Long, vararg modInts: ModularInteger) : GenericVector<ModularInteger>(
+        ModularIntegerOperations(modulus),
+        modInts.toMutableList()
+) {
 
-    constructor(modulus: Long, modularIntegers: Collection<ModularInteger>)
-            : super(ModularIntegerOperations(modulus), modularIntegers.toMutableList())
-
-    constructor(modulus: Long, size: Int, populator: (Int) -> ModularInteger)
-            : super(ModularIntegerOperations(modulus), (0 until size).map(populator).toMutableList())
+    constructor(modulus: Long, ints: Collection<ModularInteger>) : this(modulus, *ints.toTypedArray())
+    constructor(modulus: Long, size: Int, populator: (Int) -> ModularInteger) : this(modulus, *(0 until size).map(populator).toTypedArray())
 }
 
 /**
@@ -58,3 +56,21 @@ class ModularIntegerOperations(val modulus: Long) : OperationSet<ModularInteger>
         { ModularInteger.reduce(it.toLong(), modulus) },
         { i, j -> i.compareTo(j) }
 )
+
+//
+//  Extension functions
+//
+
+// Vectors
+fun Array<ModularInteger>.toVector(modulus: Long) = ModularIntegerVector(modulus, *this)
+fun Collection<ModularInteger>.toVector(modulus: Long) = ModularIntegerVector(modulus, *toTypedArray())
+infix fun ModularInteger.`&`(other: ModularInteger): ModularIntegerVector {
+    require(modulus == other.modulus) { "Moduli must be equal, got $modulus vs ${other.modulus}"}
+    return ModularIntegerVector(modulus, this, other)
+}
+fun modIntVectorOf(modulus: Long, vararg modInts: ModularInteger) = ModularIntegerVector(modulus, *modInts)
+
+// Matrices
+fun Array<Vector<ModularInteger>>.toMatrix(modulus: Long, major: Major = Major.ROW) = ModularIntegerMatrix(modulus, *this, major = major)
+fun List<Vector<ModularInteger>>.toMatrix(modulus: Long, major: Major = Major.ROW) = ModularIntegerMatrix(modulus, this, major = major)
+fun modIntMatrixOf(modulus: Long, width: Int, vararg modInts: ModularInteger) = ModularIntegerMatrix(modulus, *modInts, width = width)

--- a/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
+++ b/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
@@ -663,14 +663,11 @@ open class GenericMatrix<T> : MutableMatrix<T> {
     private operator fun T.unaryMinus() = op.negate(this)
 
     override fun toString() = buildString {
-        for (row in 0 until height()) {
-            for (col in 0 until width()) {
-                append(get(row, col))
-                append("\t")
-            }
-            append("\n")
-        }
-    }.trim()
+        val maxLength = elements.flatMap { it }.map { it.toString().length }.max() ?: return@buildString
+        val format = ("%${maxLength}s ".repeat(width()).trim() + "\n").repeat(height()).trim()
+        val strings = rows().flatMap { it }.map { it.toString() }.toTypedArray()
+        append(format.format(*strings))
+    }.trimEnd()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
+++ b/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
@@ -418,6 +418,21 @@ open class GenericMatrix<T> : MutableMatrix<T> {
         return solve.subMatrix(0, width(), width(), height())
     }
 
+    override fun negate() = when (major) {
+        // Switch on major to improve performance.
+        Major.ROW -> rows().map { it.negate() }.toMatrix(op)
+        Major.COLUMN -> columns().map { it.negate() }.toMatrix(op)
+    }
+
+    override fun negateModify(): MutableMatrix<T> {
+        for (row in 0 until height()) {
+            for (col in 0 until width()) {
+                this[row, col] = -this[row, col]
+            }
+        }
+        return this
+    }
+
     /**
      * Looks for rows below the given row with a non-zero value at the specified column and swaps it
      * with the given row.

--- a/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
+++ b/src/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
@@ -5,6 +5,15 @@ package nl.rubensten.utensils.math.matrix
  */
 open class GenericMatrix<T> : MutableMatrix<T> {
 
+    companion object {
+
+        /**
+         * Creates an empty matrix, i.e. of size 0.
+         */
+        @JvmStatic
+        fun <T> empty(operations: OperationSet<T>) = GenericMatrix(operations, emptyList())
+    }
+
     /**
      * The rows or columns in the matrix (all the same size) ordered as determined by [major].
      */
@@ -58,7 +67,6 @@ open class GenericMatrix<T> : MutableMatrix<T> {
         this.op = op
         this.major = major
         this.elements = elements
-        check(elements.isNotEmpty()) { "Matrix must not be empty!" }
     }
 
     /**
@@ -153,12 +161,12 @@ open class GenericMatrix<T> : MutableMatrix<T> {
 
     override fun major() = major
 
-    override fun width() = when (major) {
+    override fun width() = if (elements.isEmpty()) 0 else when (major) {
         Major.ROW -> elements[0].size()
         Major.COLUMN -> elements.size
     }
 
-    override fun height() = when (major) {
+    override fun height() = if (elements.isEmpty()) 0 else when (major) {
         Major.ROW -> elements.size
         Major.COLUMN -> elements[0].size()
     }
@@ -728,6 +736,18 @@ abstract class NumberMatrix<T : Number> : GenericMatrix<T> {
  */
 open class ByteMatrix : NumberMatrix<Byte> {
 
+    companion object {
+
+        /** A 0x0 byte matrix with 0 elements. **/
+        private val emptyByteMatrix = ByteMatrix(0, 0) { _, _ -> 0 }
+
+        /**
+         * Returns a 0x0 byte matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Byte> = emptyByteMatrix
+    }
+
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Byte>)
             : super(ByteOperations, major, vectors.toMutableList())
 
@@ -751,6 +771,18 @@ open class ByteMatrix : NumberMatrix<Byte> {
  * @author Ruben Schellekens
  */
 open class ShortMatrix : NumberMatrix<Short> {
+
+    companion object {
+
+        /** A 0x0 short matrix with 0 elements. **/
+        private val emptyShortMatrix = ShortMatrix(0, 0) { _, _ -> 0 }
+
+        /**
+         * Returns a 0x0 short matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Short> = emptyShortMatrix
+    }
 
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Short>)
             : super(ShortOperations, major, vectors.toMutableList())
@@ -776,6 +808,18 @@ open class ShortMatrix : NumberMatrix<Short> {
  */
 open class IntMatrix : NumberMatrix<Int> {
 
+    companion object {
+
+        /** A 0x0 int matrix with 0 elements. **/
+        private val emptyIntMatrix = IntMatrix(0, 0) { _, _ -> 0 }
+
+        /**
+         * Returns a 0x0 int matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Int> = emptyIntMatrix
+    }
+
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Int>)
             : super(IntOperations, major, vectors.toMutableList())
 
@@ -799,6 +843,18 @@ open class IntMatrix : NumberMatrix<Int> {
  * @author Ruben Schellekens
  */
 open class LongMatrix : NumberMatrix<Long> {
+
+    companion object {
+
+        /** A 0x0 long matrix with 0 elements. **/
+        private val emptyLongMatrix = LongMatrix(0, 0) { _, _ -> 0 }
+
+        /**
+         * Returns a 0x0 long matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Long> = emptyLongMatrix
+    }
 
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Long>)
             : super(LongOperations, major, vectors.toMutableList())
@@ -824,6 +880,18 @@ open class LongMatrix : NumberMatrix<Long> {
  */
 open class FloatMatrix : NumberMatrix<Float> {
 
+    companion object {
+
+        /** A 0x0 float matrix with 0 elements. **/
+        private val emptyFloatMatrix = FloatMatrix(0, 0) { _, _ -> 0f }
+
+        /**
+         * Returns a 0x0 float matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Float> = emptyFloatMatrix
+    }
+
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Float>)
             : super(FloatOperations, major, vectors.toMutableList())
 
@@ -848,6 +916,18 @@ open class FloatMatrix : NumberMatrix<Float> {
  */
 open class DoubleMatrix : NumberMatrix<Double> {
 
+    companion object {
+
+        /** A 0x0 double matrix with 0 elements. **/
+        private val emptyDoubleMatrix = DoubleMatrix(0, 0) { _, _ -> 0.0 }
+
+        /**
+         * Returns a 0x0 double matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<Double> = emptyDoubleMatrix
+    }
+
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<Double>)
             : super(DoubleOperations, major, vectors.toMutableList())
 
@@ -871,6 +951,18 @@ open class DoubleMatrix : NumberMatrix<Double> {
  * @author Ruben Schellekens
  */
 open class StringMatrix : GenericMatrix<String> {
+
+    companion object {
+
+        /** A 0x0 string matrix with 0 elements. **/
+        private val emptyStringMatrix = StringMatrix(0, 0) { _, _ -> "" }
+
+        /**
+         * Returns a 0x0 string matrix with 0 elements.
+         */
+        @JvmStatic
+        fun empty(): Matrix<String> = emptyStringMatrix
+    }
 
     constructor(major: Major = Major.ROW, vararg vectors: MutableVector<String>)
             : super(StringOperations, major, vectors.toMutableList())

--- a/src/nl/rubensten/utensils/math/matrix/GenericVector.kt
+++ b/src/nl/rubensten/utensils/math/matrix/GenericVector.kt
@@ -127,6 +127,8 @@ open class GenericVector<T>(
         return result
     }
 
+    override fun negate() = elements.map { op.negate(it) }.toVector(op)
+
     override fun length(): Double {
         var sum = op.zero
         for (element in this) {
@@ -156,38 +158,49 @@ open class GenericVector<T>(
         it.isZero()
     }
 
-    override fun addModify(other: Vector<T>) {
+    override fun addModify(other: Vector<T>): MutableVector<T> {
         checkDimensions(size(), other.size()) { "Sizes don't match, got $it" }
 
         for (i in 0 until size()) {
             elements[i] = op.add(elements[i], other[i])
         }
+        return this
     }
 
-    override fun subtractModify(other: Vector<T>) {
+    override fun subtractModify(other: Vector<T>): MutableVector<T> {
         checkDimensions(size(), other.size()) { "Sizes don't match, got $it" }
 
         for (i in 0 until size()) {
             elements[i] = op.subtract(elements[i], other[i])
         }
+        return this
     }
 
-    override fun scalarModify(scalar: T) {
+    override fun scalarModify(scalar: T): MutableVector<T> {
         for (i in 0 until size()) {
             elements[i] = op.multiply(elements[i], scalar)
         }
+        return this
     }
 
-    override fun normalizeModify() {
+    override fun negateModify(): MutableVector<T> {
+        for (i in 0 until size()) {
+            elements[i] = op.negate(elements[i])
+        }
+        return this
+    }
+
+    override fun normalizeModify(): MutableVector<T> {
         val length = length()
         if (length.isZero()) {
-            return
+            return this
         }
 
         val scalar = op.inverse(op.fromDouble(length))
         for (i in 0 until size()) {
             this[i] = op.multiply(this[i], scalar)
         }
+        return this
     }
 
     override fun append(other: T): Vector<T> {

--- a/src/nl/rubensten/utensils/math/matrix/Matrix.kt
+++ b/src/nl/rubensten/utensils/math/matrix/Matrix.kt
@@ -559,3 +559,13 @@ fun List<Vector<Float>>.toMatrix(major: Major = Major.ROW) = FloatMatrix(this, m
 fun List<Vector<Double>>.toMatrix(major: Major = Major.ROW) = DoubleMatrix(this, major = major)
 fun List<Vector<String>>.toMatrix(major: Major = Major.ROW) = StringMatrix(this, major = major)
 fun <T> List<Vector<T>>.toMatrix(operations: OperationSet<T>, major: Major = Major.ROW) = GenericMatrix(operations, this, major = major)
+
+// Creation functions.
+fun byteMatrixOf(width: Int, vararg bytes: Byte) = ByteMatrix(*bytes, width = width)
+fun shortMatrixOf(width: Int, vararg shorts: Short) = ShortMatrix(*shorts, width = width)
+fun intMatrixOf(width: Int, vararg ints: Int) = IntMatrix(*ints, width = width)
+fun longMatrixOf(width: Int, vararg longs: Long) = LongMatrix(*longs, width = width)
+fun floatMatrixOf(width: Int, vararg floats: Float) = FloatMatrix(*floats, width = width)
+fun doubleMatrixOf(width: Int, vararg doubles: Double) = DoubleMatrix(*doubles, width = width)
+fun stringMatrixOf(width: Int, vararg strings: String) = StringMatrix(*strings, width = width)
+fun <T> matrixOf(operations: OperationSet<T>, width: Int, vararg elements: T) = GenericMatrix(operations, width = width, elements = *elements)

--- a/src/nl/rubensten/utensils/math/matrix/Matrix.kt
+++ b/src/nl/rubensten/utensils/math/matrix/Matrix.kt
@@ -286,6 +286,13 @@ interface Matrix<T> : Iterable<Vector<T>> {
     fun inverse(): Matrix<T>?
 
     /**
+     * Negates all aelements of the matrix.
+     *
+     * @return A new matrix with all elements negated according to the [OperationSet].
+     */
+    fun negate(): Matrix<T>
+
+    /**
      * Get the order of the matrix.
      *
      * I.e. the value of `n` for which `A^n = I`.
@@ -381,6 +388,12 @@ interface Matrix<T> : Iterable<Vector<T>> {
 
     /** See [multiply(Vector)] **/
     operator fun times(other: Vector<T>) = multiply(other)
+
+    /** See [negate] **/
+    operator fun unaryMinus() = negate()
+
+    /** Does nothing with the matrix, just returns `this` **/
+    operator fun unaryPlus() = this
 }
 
 /**
@@ -475,6 +488,13 @@ interface MutableMatrix<T> : Matrix<T> {
     fun scalarColumnModify(column: Int, scalar: T): MutableMatrix<T>
 
     /**
+     * See [negate], but then modifies the matrix instead of returning a new one.
+     *
+     * @return The modified matrix with all elements negated according to the [OperationSet].
+     */
+    fun negateModify(): MutableMatrix<T>
+
+    /**
      * Creates a copy of the matrix. Results in an immutable matrix.
      */
     fun clone(): Matrix<T> = mutableClone()
@@ -519,3 +539,23 @@ enum class Major {
      */
     ROW
 }
+
+// Convert arrays of vectors to matrices.
+fun Array<Vector<Byte>>.toMatrix(major: Major = Major.ROW) = ByteMatrix(*this, major = major)
+fun Array<Vector<Short>>.toMatrix(major: Major = Major.ROW) = ShortMatrix(*this, major = major)
+fun Array<Vector<Int>>.toMatrix(major: Major = Major.ROW) = IntMatrix(*this, major = major)
+fun Array<Vector<Long>>.toMatrix(major: Major = Major.ROW) = LongMatrix(*this, major = major)
+fun Array<Vector<Float>>.toMatrix(major: Major = Major.ROW) = FloatMatrix(*this, major = major)
+fun Array<Vector<Double>>.toMatrix(major: Major = Major.ROW) = DoubleMatrix(*this, major = major)
+fun Array<Vector<String>>.toMatrix(major: Major = Major.ROW) = StringMatrix(*this, major = major)
+fun <T> Array<Vector<T>>.toMatrix(operations: OperationSet<T>, major: Major = Major.ROW) = GenericMatrix(operations, toMutableList(), major = major)
+
+// Convert collections of vectors to matrices.
+fun List<Vector<Byte>>.toMatrix(major: Major = Major.ROW) = ByteMatrix(this, major = major)
+fun List<Vector<Short>>.toMatrix(major: Major = Major.ROW) = ShortMatrix(this, major = major)
+fun List<Vector<Int>>.toMatrix(major: Major = Major.ROW) = IntMatrix(this, major = major)
+fun List<Vector<Long>>.toMatrix(major: Major = Major.ROW) = LongMatrix(this, major = major)
+fun List<Vector<Float>>.toMatrix(major: Major = Major.ROW) = FloatMatrix(this, major = major)
+fun List<Vector<Double>>.toMatrix(major: Major = Major.ROW) = DoubleMatrix(this, major = major)
+fun List<Vector<String>>.toMatrix(major: Major = Major.ROW) = StringMatrix(this, major = major)
+fun <T> List<Vector<T>>.toMatrix(operations: OperationSet<T>, major: Major = Major.ROW) = GenericMatrix(operations, this, major = major)

--- a/src/nl/rubensten/utensils/math/matrix/Vector.kt
+++ b/src/nl/rubensten/utensils/math/matrix/Vector.kt
@@ -322,3 +322,12 @@ infix fun String.`&`(other: String) = GenericVector(StringOperations, this, othe
 
 infix fun <T> Vector<T>.`&`(other: T) = append(other)
 infix fun <T> Vector<T>.`&`(other: Vector<T>) = append(other)
+
+fun byteVectorOf(vararg bytes: Byte) = ByteVector(*bytes)
+fun shortVectorOf(vararg shorts: Short) = ShortVector(*shorts)
+fun intVectorOf(vararg ints: Int) = IntVector(*ints)
+fun longVectorOf(vararg longs: Long) = LongVector(*longs)
+fun floatVectorOf(vararg floats: Float) = FloatVector(*floats)
+fun doubleVectorOf(vararg doubles: Double) = DoubleVector(*doubles)
+fun stringVectorOf(vararg strings: String) = StringVector(*strings)
+fun <T> vectorOf(operations: OperationSet<T>, vararg elements: T) = GenericVector(operations, *elements)

--- a/src/nl/rubensten/utensils/math/matrix/Vector.kt
+++ b/src/nl/rubensten/utensils/math/matrix/Vector.kt
@@ -100,6 +100,13 @@ interface Vector<T>: Iterable<T> {
     infix fun scalar(value: T): Vector<T>
 
     /**
+     * Negates all aelements of the vector.
+     *
+     * @return A new vector with all elements negated according to the [OperationSet].
+     */
+    fun negate(): Vector<T>
+
+    /**
      * Calculates the pythagorean length of the vector.
      *
      * @return The length of the vector.
@@ -219,6 +226,12 @@ interface Vector<T>: Iterable<T> {
 
     /** See [scalar] **/
     operator fun times(scalar: T) = scalar(scalar)
+
+    /** See [negate] **/
+    operator fun unaryMinus() = negate()
+
+    /** Returns this vector **/
+    operator fun unaryPlus() = this
 }
 
 /**
@@ -230,23 +243,38 @@ interface MutableVector<T> : Vector<T> {
 
     /**
      * See [add], but then modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
      */
-    fun addModify(other: Vector<T>)
+    fun addModify(other: Vector<T>): MutableVector<T>
 
     /**
      * See [subtract], but then modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
      */
-    fun subtractModify(other: Vector<T>)
+    fun subtractModify(other: Vector<T>): MutableVector<T>
 
     /**
      * See [scalar], but the modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
      */
-    fun scalarModify(scalar: T)
+    fun scalarModify(scalar: T): MutableVector<T>
+
+    /**
+     * See [negate], but then modifies the vector instead of returning a new one.
+     *
+     * @return The modified vector with all elements negated according to the [OperationSet].
+     */
+    fun negateModify(): MutableVector<T>
 
     /**
      * See [normalize], but then modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
      */
-    fun normalizeModify()
+    fun normalizeModify(): MutableVector<T>
 
     /**
      * Create a clone of this vector.

--- a/src/nl/rubensten/utensils/math/optimization/HungarianAlgorithm.kt
+++ b/src/nl/rubensten/utensils/math/optimization/HungarianAlgorithm.kt
@@ -208,7 +208,6 @@ class HungarianAlgorithm<T, W, J>(
         }
 
         fun Pair<Int, Int>.isAssigned() = assignedZeroes.contains(this)
-        fun Pair<Int, Int>.isCrossedOut() = crossedZeroes.contains(this)
 
         // Step 1:
         // Assign as many tasks as possible.
@@ -437,16 +436,6 @@ class HungarianAlgorithm<T, W, J>(
         cost = result.mapIndexed { job, worker -> costMatrix[worker!!, job] }
                 .reduce { acc, t -> acc + t }
     }
-
-    /**
-     * Counts the amount of zeroes in the given row. `O(n)`
-     */
-    private fun countRowZeroes(rowIndex: Int) = matrix.getRow(rowIndex).count { it.isZero() }
-
-    /**
-     * Counts the amount of zeroes in the given column. `O(n)`
-     */
-    private fun countColumnZeroes(columnIndex: Int) = matrix.getColumn(columnIndex).count { it.isZero() }
 
     /**
      * Finds all the zeroes in the given row. `O(n)`


### PR DESCRIPTION
# Changes
- Empty matrix support.
- Added support for unary minus and unary plus for Matrix/Vector.
- Added extentions to convert `List<Vector<T>>` or `Array<Vector<T>>` to matrix (`toMatrix`).
- Added `matrixOf` and `intMatrixOf` variants.
- Added `vectorOf` and `intVectorOf` variants.
- Updated matrix toString to have same (fixed) with cells. (see image)
- Added complex numbers and corresponding operations/vectors/matrices. (`ComplexVector` and `ComplexMatrix`)
- Added extension property `i` to convert numbers to Complex numbers. E.g. `4.5f.i` becomes `Complex(0.0, 4.5)`.

# Images
![image](https://user-images.githubusercontent.com/17410729/34522265-1214872c-f092-11e7-8c88-e61554c4c4bc.png)

![image](https://user-images.githubusercontent.com/17410729/34522478-1acf31c2-f093-11e7-801d-e0c98f2f0592.png)

![image](https://user-images.githubusercontent.com/17410729/34522487-2060095e-f093-11e7-99ea-06dbe9df3f65.png)

![image](https://user-images.githubusercontent.com/17410729/34522681-18f86034-f094-11e7-9080-cb1114f0a1e7.png)

  