### PR TITLE
Added element wise product/division

### DIFF
--- a/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
+++ b/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
@@ -261,6 +261,16 @@ open class GenericMatrix<T> : MutableMatrix<T> {
         return multiply(other.toMatrix()).getColumn(0)
     }
 
+    override fun elementWiseProduct(other: Matrix<T>): Matrix<T> {
+        checkDimensions(this, other)
+        return mutableClone().elementWiseProductModify(other)
+    }
+
+    override fun elementWiseDivision(other: Matrix<T>): Matrix<T> {
+        checkDimensions(this, other)
+        return mutableClone().elementWiseDivisionModify(other)
+    }
+
     override fun power(exponent: Int): Matrix<T> {
         require(exponent >= 0) { "Exponent must be non-negative, got $exponent" }
         checkSquare(this)
@@ -574,6 +584,28 @@ open class GenericMatrix<T> : MutableMatrix<T> {
     override fun scalarColumnModify(column: Int, scalar: T): MutableMatrix<T> {
         for (row in 0 until height()) {
             this[row, column] *= scalar
+        }
+        return this
+    }
+
+    override fun elementWiseProductModify(other: Matrix<T>): MutableMatrix<T> {
+        checkDimensions(this, other)
+
+        for (row in 0 until height) {
+            for (col in 0 until width) {
+                this[row, col] = this[row, col] * other[row, col]
+            }
+        }
+        return this
+    }
+
+    override fun elementWiseDivisionModify(other: Matrix<T>): MutableMatrix<T> {
+        checkDimensions(this, other)
+
+        for (row in rowIndices) {
+            for (col in columnIndices) {
+                this[row, col] = op.division(this[row, col], other[row, col])
+            }
         }
         return this
     }

--- a/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
+++ b/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericMatrix.kt
@@ -419,7 +419,7 @@ open class GenericMatrix<T> : MutableMatrix<T> {
         for (i in 0 until solve.height()) {
             solve.swapToNonZero(i, i)
             val value = solve[i, i]
-            solve.scalarRow(i, value.inverse())
+            solve.scalarRowModify(i, value.inverse())
 
             for (j in 0 until solve.height()) {
                 if (j == i) {

--- a/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericVector.kt
+++ b/src/main/kotlin/nl/rubensten/utensils/math/matrix/GenericVector.kt
@@ -118,6 +118,16 @@ open class GenericVector<T>(
         return result
     }
 
+    override fun elementWiseProduct(other: Vector<T>): Vector<T> {
+        checkDimensions(size, other.size) { "Sizes don't match, got $it" }
+        return mapElementsIndexed { index, element -> op.multiply(element, other[index]) }
+    }
+
+    override fun elementWiseDivision(other: Vector<T>): Vector<T> {
+        checkDimensions(size, other.size) { "Sizes don't match, got $it" }
+        return mapElementsIndexed { index, element -> op.division(element, other[index]) }
+    }
+
     override fun scalar(value: T): Vector<T> {
         val result = clone()
         for (i in 0 until size()) {
@@ -177,6 +187,24 @@ open class GenericVector<T>(
 
         for (i in 0 until size()) {
             elements[i] = op.subtract(elements[i], other[i])
+        }
+        return this
+    }
+
+    override fun elementWiseProductModify(other: Vector<T>): MutableVector<T> {
+        checkDimensions(size, other.size) { "Sizes don't match, got $it" }
+
+        for (index in indices) {
+            elements[index] = op.multiply(elements[index], other[index])
+        }
+        return this
+    }
+
+    override fun elementWiseDivisionModify(other: Vector<T>): MutableVector<T> {
+        checkDimensions(size, other.size) { "Sizes don't match, got $it" }
+
+        for (index in indices) {
+            elements[index] = op.division(elements[index], other[index])
         }
         return this
     }

--- a/src/main/kotlin/nl/rubensten/utensils/math/matrix/Matrix.kt
+++ b/src/main/kotlin/nl/rubensten/utensils/math/matrix/Matrix.kt
@@ -22,6 +22,12 @@ interface Matrix<T> : Iterable<Vector<T>> {
         get() = width()
 
     /**
+     * Integer range containing valid column indices.
+     */
+    val columnIndices: IntRange
+        get() = 0..(width - 1)
+
+    /**
      * The amount of columns the matrix has.
      */
     fun width(): Int
@@ -31,6 +37,12 @@ interface Matrix<T> : Iterable<Vector<T>> {
      */
     val height: Int
         get() = height()
+
+    /**
+     * Integer range containing valid row indices.
+     */
+    val rowIndices: IntRange
+        get() = 0..(height - 1)
 
     /**
      * The amount of rows the matrix has.
@@ -218,6 +230,30 @@ interface Matrix<T> : Iterable<Vector<T>> {
      *         When the matrices don't have the right dimension to multiply.
      */
     infix fun multiply(other: Vector<T>): Vector<T>
+
+    /**
+     * Calculates the element wise product of two matrices.
+     *
+     * @param other
+     *         The matrix to multiply with.
+     * @return A matrix where every element is the product of the elements of the input matrices at the same indices.
+     *         E.g. ```[1, 2, 3] elementWiseProduct [4, 5, 6]``` results in the matrix ```[4, 10, 18]```.
+     * @throws DimensionMismatchException
+     *         When the matrices do not have the same dimensions.
+     */
+    infix fun elementWiseProduct(other: Matrix<T>): Matrix<T>
+
+    /**
+     * Calculates the element wise division of two matrices.
+     *
+     * @param other
+     *         The matrix to divide by.
+     * @return A matrix where every element is the division of the elements of the input matrices at the same indices.
+     *         E.g. ```[8, 16, 32] elementWiseDivision [1, 2, 4]``` results in the matrix ```[8, 8, 8]```.
+     * @throws DimensionMismatchException
+     *         When the matrices do not have the same dimensions.
+     */
+    infix fun elementWiseDivision(other: Matrix<T>): Matrix<T>
 
     /**
      * Raises this matrix to a given power.
@@ -510,51 +546,65 @@ interface MutableMatrix<T> : Matrix<T> {
     /**
      * See [swapRow], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun swapRowModify(row0: Int, row1: Int): MutableMatrix<T>
 
     /**
      * See [swapColumn], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun swapColumnModify(col0: Int, col1: Int): MutableMatrix<T>
 
     /**
      * See [add], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun addModify(other: Matrix<T>): MutableMatrix<T>
 
     /**
      * See [subtract], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun subtractModify(other: Matrix<T>): MutableMatrix<T>
 
     /**
      * See [scalar], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun scalarModify(scalar: T): MutableMatrix<T>
 
     /**
      * See [scalarRow], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun scalarRowModify(row: Int, scalar: T): MutableMatrix<T>
 
     /**
      * See [scalarColumn], but then modifies the matrix instead of returning a new one.
      *
-     * @return `this`
+     * @return `this` (modified) matrix.
      */
     fun scalarColumnModify(column: Int, scalar: T): MutableMatrix<T>
+
+    /**
+     * See [elementWiseProduct], but then modifies the matrix instead of returning a new one.
+     *
+     * @return `this` (modified) matrix.
+     */
+    infix fun elementWiseProductModify(other: Matrix<T>): MutableMatrix<T>
+
+    /**
+     * See [elementWiseDivision], but then modifies the matrix instead of returning a new one.
+     *
+     * @return `this` (modified) matrix.
+     */
+    infix fun elementWiseDivisionModify(other: Matrix<T>): MutableMatrix<T>
 
     /**
      * See [negate], but then modifies the matrix instead of returning a new one.

--- a/src/main/kotlin/nl/rubensten/utensils/math/matrix/Vector.kt
+++ b/src/main/kotlin/nl/rubensten/utensils/math/matrix/Vector.kt
@@ -152,6 +152,12 @@ interface Vector<T>: Iterable<T> {
         get() = xyzw
 
     /**
+     * Integer range containing valid indices of the vector.
+     */
+    val indices: IntRange
+        get() = 0..(size - 1)
+
+    /**
      * The amount of elements in the vector.
      */
     val size: Int
@@ -181,6 +187,13 @@ interface Vector<T>: Iterable<T> {
      * @return An array of vectors that form a basis for the dimension of this vector.
      */
     fun extendToBasis() = MatrixUtils.extendToBasis(this)
+
+    /**
+     * Calls [MatrixUtils.orthonormalBasisContaining] with only this vector as parameter.
+     *
+     * @return A list of vectors all with length 1 and perpendicular to each other.
+     */
+    fun orthonormalBasisContaining() = MatrixUtils.orthonormalBasisContaining(this)
 
     /**
      * Calculates the perpendicular projection to other vectors.
@@ -241,6 +254,30 @@ interface Vector<T>: Iterable<T> {
      *         When either this or the other vector has a size not equal to 3.
      */
     infix fun cross(other: Vector<T>): Vector<T>
+
+    /**
+     * Calculates the element wise product of two vectors.
+     *
+     * @param other
+     *         The vector to multiply with.
+     * @return A vector where every element is the product of the elements of the input vectors at the same index.
+     *         E.g. ```[1, 2, 3] elementWiseProduct [4, 5, 6]``` results in the vector ```[4, 10, 18]```.
+     * @throws DimensionMismatchException
+     *         When the vectors do not have the same size.
+     */
+    infix fun elementWiseProduct(other: Vector<T>): Vector<T>
+
+    /**
+     * Calculates the element wise division of two vectors.
+     *
+     * @param other
+     *         The vector to divide by.
+     * @return A vector where every element is the division of the elements of the input vectors at the same index.
+     *         E.g. ```[8, 16, 32] elementWiseDivision [1, 2, 4]``` results in the vector ```[8, 8, 8]```.
+     * @throws DimensionMismatchException
+     *         When the vectors do not have the same size.
+     */
+    infix fun elementWiseDivision(other: Vector<T>): Vector<T>
 
     /**
      * Multiplies all the elements of the vector by a given value.
@@ -421,6 +458,20 @@ interface MutableVector<T> : Vector<T> {
      * @return This (modified) vector.
      */
     infix fun subtractModify(other: Vector<T>): MutableVector<T>
+
+    /**
+     * See [elementWiseProduct], but then modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
+     */
+    infix fun elementWiseProductModify(other: Vector<T>): MutableVector<T>
+
+    /**
+     * See [elementWiseDivision], but then modifies the vector instead of returning a new one.
+     *
+     * @return This (modified) vector.
+     */
+    infix fun elementWiseDivisionModify(other: Vector<T>): MutableVector<T>
 
     /**
      * See [scalar], but the modifies the vector instead of returning a new one.


### PR DESCRIPTION
# Changes
- Added element wise product and division (and modify variants) to `Matrix` and `Vector`.
- Added `indices` to `Vector` creating an `IntRange` of the vector's indices.
- Similarly added `rowIndices` and `columnIndices` for `Matrix`.
- Fixed `GenericMatrix.inverse()` using `scalarRow(..)` instead of `scalarRowModify(..)`.
- Added `Vector.orthonormalBasisContaining()` as alternative to `MatrixUtils.orthonormalBasisContaining(Vector)`.